### PR TITLE
fix: add 'devlog' to content check script's allowed kinds

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,29 @@
+name: Validate PR
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: validate-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting, lint, validate content, and build
+        run: npm run check

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist
 .astro
 public/images
 .env.example
+public/google*.html

--- a/scripts/check-content.mjs
+++ b/scripts/check-content.mjs
@@ -16,6 +16,7 @@ const allowedKinds = new Set([
   'retrospective',
   'study',
   'note',
+  'devlog',
 ]);
 const allowedTopics = new Set([
   'cpp',


### PR DESCRIPTION
## Summary
- PR #2 added the `devlog` blog `kind` to `content.config.ts`, `lib/blog.ts`, and `PostMetaBadges.astro`, but missed `scripts/check-content.mjs`, which keeps its own separate `allowedKinds` list. `npm run content:check` failed on both devlog posts after merge.
- Adds `'devlog'` to that list too.

## Test plan
- [x] `npm run content:check` passes locally (19 files checked, 0 errors)
- [x] `npm run build` still passes