### PR TITLE
fix: add 'devlog' to Sveltia CMS kind dropdown

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -79,6 +79,7 @@ collections:
           - { label: "Retrospective", value: "retrospective" }
           - { label: "Study", value: "study" }
           - { label: "Note", value: "note" }
+          - { label: "Devlog", value: "devlog" }
 
       - label: "Topic"
         name: "topic"


### PR DESCRIPTION
## Summary
- The `kind` select field in `public/admin/config.yml` (Sveltia CMS admin UI) had its own separate hardcoded option list, so `devlog` didn't show up in the CMS dropdown even though it's valid in the schema/content-check/build.
- This is the 5th place this list was duplicated (`content.config.ts`, `lib/blog.ts`, `PostMetaBadges.astro`, `scripts/check-content.mjs`, and now this CMS config) — all now consistent.

## Test plan
- [x] `npm run check` passes locally (format, lint, content:check, build)