### PR TITLE
P3: About CMS 등록, STL 시리즈 정리, Mermaid 테마 재렌더

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -113,7 +113,6 @@ collections:
               label: "AI Curator 파이프라인 구축기",
               value: "ai-curator-pipeline",
             }
-          - { label: "C++ STL Study", value: "cpp-stl-study" }
           - { label: "LLM Core", value: "llm-core" }
           - { label: "LLM Training", value: "llm-training" }
 

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -157,6 +157,21 @@ collections:
             required: false
           - { label: "Body", name: "body", widget: "markdown" }
 
+  - name: "about"
+    label: "About"
+    files:
+      - label: "About Page"
+        name: "about"
+        file: "src/content/about.md"
+        fields:
+          - {
+              label: "Title",
+              name: "title",
+              widget: "hidden",
+              default: "About",
+            }
+          - { label: "Body", name: "body", widget: "markdown" }
+
   - name: "projects"
     label: "Projects"
     folder: "src/content/projects"

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -71,4 +71,11 @@ const now = defineCollection({
   }),
 });
 
-export const collections = { projects, blog, now };
+const about = defineCollection({
+  loader: glob({ pattern: 'about.md', base: './src/content' }),
+  schema: z.object({
+    title: z.string().default('About'),
+  }),
+});
+
+export const collections = { projects, blog, now, about };

--- a/src/data/taxonomy.json
+++ b/src/data/taxonomy.json
@@ -27,11 +27,6 @@
       "description": "기술 뉴스 자동 수집·요약·배포 파이프라인 구축 기록입니다."
     },
     {
-      "id": "cpp-stl-study",
-      "title": "C++ STL Study",
-      "description": "C++ STL과 자료구조를 실무 관점에서 정리합니다."
-    },
-    {
       "id": "llm-core",
       "title": "LLM Core",
       "description": "Transformer부터 decoding까지, LLM이 텍스트를 생성하는 핵심 원리를 단계별로 정리합니다."

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,9 @@
 ---
-import AboutContent from '../content/about.md';
+import { getEntry, render } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
+
+const aboutEntry = await getEntry('about', 'about');
+const { Content: AboutContent } = await render(aboutEntry);
 ---
 
 <BaseLayout

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -353,32 +353,81 @@ const blogPostingStructuredData = {
       });
     };
 
-    const renderMermaid = async () => {
-      const diagrams = document.querySelectorAll('.mermaid');
+    if (document.querySelectorAll('.mermaid').length) {
+      let tabsEnhanced = false;
+      let isRerendering = false;
 
-      if (!diagrams.length) {
-        return;
+      const rerenderMermaid = async () => {
+        if (isRerendering) {
+          return;
+        }
+
+        isRerendering = true;
+
+        try {
+          const diagrams = document.querySelectorAll('.mermaid');
+
+          if (!diagrams.length) {
+            return;
+          }
+
+          const { default: mermaid } = await import('mermaid');
+
+          diagrams.forEach((el) => {
+            if (!el.getAttribute('data-mermaid-source')) {
+              el.setAttribute('data-mermaid-source', el.textContent ?? '');
+            }
+
+            const source = el.getAttribute('data-mermaid-source');
+            if (source !== null) {
+              el.removeAttribute('data-processed');
+              el.textContent = source;
+            }
+          });
+
+          mermaid.initialize({
+            startOnLoad: false,
+            theme: document.documentElement.classList.contains('dark')
+              ? 'dark'
+              : 'default',
+          });
+
+          await mermaid.run({ nodes: Array.from(diagrams) });
+
+          if (!tabsEnhanced) {
+            enhanceMermaidTabs();
+            tabsEnhanced = true;
+          }
+        } finally {
+          isRerendering = false;
+        }
+      };
+
+      const initMermaid = () => {
+        rerenderMermaid();
+
+        let lastDark = document.documentElement.classList.contains('dark');
+
+        new MutationObserver(() => {
+          const isDark = document.documentElement.classList.contains('dark');
+
+          if (isDark !== lastDark) {
+            lastDark = isDark;
+            rerenderMermaid();
+          }
+        }).observe(document.documentElement, {
+          attributes: true,
+          attributeFilter: ['class'],
+        });
+      };
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initMermaid, {
+          once: true,
+        });
+      } else {
+        initMermaid();
       }
-
-      const { default: mermaid } = await import('mermaid');
-
-      mermaid.initialize({
-        startOnLoad: false,
-        theme: document.documentElement.classList.contains('dark')
-          ? 'dark'
-          : 'default',
-      });
-
-      await mermaid.run({ nodes: Array.from(diagrams) });
-      enhanceMermaidTabs();
-    };
-
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', renderMermaid, {
-        once: true,
-      });
-    } else {
-      renderMermaid();
     }
   </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- About 페이지를 Now와 동일하게 Sveltia CMS file collection으로 등록 (#13)
- 소속 글이 없던 `cpp-stl-study` 시리즈 정의 제거 (#14, 권장 옵션 (a) 선택 — STL 연재 계획이 생기면 taxonomy.json + config.yml 두 곳만 다시 추가)
- 테마 토글 시 Mermaid 다이어그램이 이전 테마 색으로 고정되던 문제 수정 (#15) — 원본 소스를 보존해두고 MutationObserver로 `<html>` 클래스 변경을 감지해 현재 테마로 재렌더링

## Test plan
- [x] `npm run check` 통과 (매 커밋마다)
- [x] `/about` 페이지 렌더링 확인, About 컬렉션이 config.yml에 등록됨
- [x] Playwright로 프로덕션 빌드(`astro preview`)에서 직접 검증: 다이어그램이 있는 글에서 테마 토글 → SVG rect fill이 `rgb(236,236,255)`(light) ↔ `rgb(31,32,32)`(dark)로 정확히 전환, 재토글 시 원복, 콘솔 에러 없음. 스크린샷으로 시각 확인 완료
- [ ] 실제 배포 후 육안 재확인은 선택 사항

## Note
검증 과정에서 Mermaid 탭(Mermaid/Code 전환 버튼)이 `main`에도 이미 존재하는 기존 버그로 전혀 렌더링되지 않는 것을 발견했습니다 (`.mermaid` 요소가 `<figure>`의 유일한 자식이라 `previousElementSibling`이 항상 null이어서 `enhanceMermaidTabs`의 코드블록 탐지 로직이 매칭되지 않음). 이번 PR의 변경과 무관하고 #15 범위 밖이라 손대지 않았습니다. 원하시면 별도 이슈로 등록하겠습니다.

Closes #13, #14, #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)