### PR TITLE
chore: 미사용 release kind 제거

### DIFF
--- a/docs/cms-writing-guide.md
+++ b/docs/cms-writing-guide.md
@@ -29,10 +29,10 @@
 
 - `design`: 설계 노트
 - `implementation`: 구현 기록
-- `release`: 릴리즈/배포 기록
 - `retrospective`: 회고
 - `study`: 개인 학습
 - `note`: 기타 노트
+- `devlog`: 트러블슈팅 등 개발 일지
 
 ### Tags
 

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -81,7 +81,6 @@ collections:
         options:
           - { label: "Design", value: "design" }
           - { label: "Implementation", value: "implementation" }
-          - { label: "Release", value: "release" }
           - { label: "Retrospective", value: "retrospective" }
           - { label: "Study", value: "study" }
           - { label: "Note", value: "note" }

--- a/src/components/PostMetaBadges.astro
+++ b/src/components/PostMetaBadges.astro
@@ -21,8 +21,6 @@ const kindStyles: Record<BlogKind, string> = {
     'bg-azure-500/15 text-azure-700 dark:bg-azure-500/15 dark:text-azure-400',
   implementation:
     'bg-green-100/50 text-green-700 dark:bg-green-900/50 dark:text-green-300',
-  release:
-    'bg-amber-100/50 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300',
   retrospective:
     'bg-purple-100/50 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300',
   study: 'bg-cyan-100/50 text-cyan-700 dark:bg-cyan-900/50 dark:text-cyan-300',

--- a/src/data/taxonomy.json
+++ b/src/data/taxonomy.json
@@ -7,7 +7,6 @@
   "kinds": [
     { "id": "design", "label": "Design" },
     { "id": "implementation", "label": "Implementation" },
-    { "id": "release", "label": "Release" },
     { "id": "retrospective", "label": "Retrospective" },
     { "id": "study", "label": "Study" },
     { "id": "note", "label": "Note" },


### PR DESCRIPTION
## Summary
- 한 번도 쓰인 적 없고 릴리즈 글 작성 계획도 없는 `release` kind를 taxonomy.json/config.yml/PostMetaBadges에서 제거
- CMS 작성 가이드의 Kind 목록에 빠져 있던 `devlog` 항목 추가 (실제 발행 글 2편에서 쓰이는데 문서화가 안 되어 있었음)

## Note
분류 체계 검토 중 unilink 시리즈가 전부 `design` kind인 것도 살펴봤는데, 실제 글들의 코드 블록 비중을 재보니(45~55%로 균일) design/implementation을 인위적으로 나눌 근거가 없어 그대로 뒀습니다. STL 글도 아카이브 목적의 단발성 글이라 시리즈 없이 현재 상태 유지.

## Test plan
- [x] `npm run check` 통과
- [x] `grep`으로 release 관련 참조 완전히 제거됐는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)