### PR TITLE
refactor: /blog Latest 섹션을 최근 5개로 제한

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -12,6 +12,8 @@ import {
 } from '../../lib/blog';
 import { seriesList } from '../../lib/taxonomy';
 
+const RECENT_POSTS_LIMIT = 5;
+
 const posts = await getPublishedBlogPosts();
 const projectGroups = (['unilink', 'ai-curator'] as BlogProject[])
   .map((project) => ({
@@ -21,6 +23,7 @@ const projectGroups = (['unilink', 'ai-curator'] as BlogProject[])
   .filter((group) => group.posts.length > 0);
 const studyPosts = getStudyPosts(posts);
 const sitePosts = getSitePosts(posts);
+const recentPosts = posts.slice(0, RECENT_POSTS_LIMIT);
 const getProjectDocTitle = (project: BlogProject) =>
   seriesList.find((series) => series.project === project)?.title ??
   projectLabels[project];
@@ -136,7 +139,7 @@ const getProjectDocTitle = (project: BlogProject) =>
       </h2>
       <ul>
         {
-          posts.map((post) => (
+          recentPosts.map((post) => (
             <li class="border-b border-stone-200 dark:border-stone-800 py-6 first:pt-0 last:border-b-0 last:pb-0">
               <PostListItem post={post} variant="row" headingLevel="h2" />
             </li>


### PR DESCRIPTION
## Summary
여러 종류의 글이 `/blog` 한 페이지에 어떻게 배치되는지 검토한 결과 반영:
- 기존 "Latest" 섹션이 발행된 글 전체(25편)를 flat list로 보여줘서, 바로 위 Study Notes(7편)·Site Notes(2편) 전체와 100% 중복되고, Project Docs에서 카드로만 요약된 프로젝트 글(unilink 14편+ai-curator 2편)까지 개별 노출되고 있었음
- 글이 늘어날수록 이 섹션만 무한정 길어지는 구조라서, 최근 5개로 캡

## Test plan
- [x] `npm run check` 통과
- [x] 빌드 결과에서 Latest 섹션 항목 수가 5개인지 확인
- [x] Playwright로 프리뷰 빌드 전체 페이지 스크린샷 확인 — 페이지 길이 대폭 축소, 레이아웃 정상

## Note
현재는 최근 활동이 전부 LLM study 글이라 Study Notes와 Latest의 상위 5개가 우연히 겹치는데, 콘텐츠 종류가 다양해지면 자연히 해소되는 부분입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)