### PR TITLE
content: unilink/ai-curator/STL 글 제목의 [프로젝트] 접두어 제거

### DIFF
--- a/src/content/blog/2026-04-21-stl-priority-queue.md
+++ b/src/content/blog/2026-04-21-stl-priority-queue.md
@@ -1,5 +1,5 @@
 ---
-title: '[STL] Priority queue'
+title: 'Priority queue'
 date: 2026-04-21
 kind: study
 tags:

--- a/src/content/blog/2026-04-23-ai-curator-파이프라인-구축-방안.md
+++ b/src/content/blog/2026-04-23-ai-curator-파이프라인-구축-방안.md
@@ -1,5 +1,5 @@
 ---
-title: '[AI Curator] 파이프라인 구축 방안'
+title: '파이프라인 구축 방안'
 date: 2026-04-23
 project: ai-curator
 kind: design

--- a/src/content/blog/2026-04-25-ai-curator-파이프라인-구축기-—-실제-구현.md
+++ b/src/content/blog/2026-04-25-ai-curator-파이프라인-구축기-—-실제-구현.md
@@ -1,5 +1,5 @@
 ---
-title: '[AI Curator] 파이프라인 구축기 — 실제 구현'
+title: '파이프라인 구축기 — 실제 구현'
 date: 2026-04-25
 project: ai-curator
 kind: implementation

--- a/src/content/blog/2026-05-31-unilink-builder-api-설계.md
+++ b/src/content/blog/2026-05-31-unilink-builder-api-설계.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] builder API 설계'
+title: 'Builder API 설계'
 date: 2026-05-31
 project: unilink
 kind: design

--- a/src/content/blog/2026-05-31-unilink-unified-api-설계.md
+++ b/src/content/blog/2026-05-31-unilink-unified-api-설계.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] unified API 설계'
+title: 'Unified API 설계'
 date: 2026-05-31
 project: unilink
 kind: design

--- a/src/content/blog/2026-05-31-unilink-설계-배경.md
+++ b/src/content/blog/2026-05-31-unilink-설계-배경.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] 설계 배경'
+title: '설계 배경'
 date: 2026-05-31
 project: unilink
 kind: design

--- a/src/content/blog/2026-06-02-unilink-channel-추상화-설계.md
+++ b/src/content/blog/2026-06-02-unilink-channel-추상화-설계.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] channel 추상화 설계'
+title: 'Channel 추상화 설계'
 date: 2026-06-02
 project: unilink
 kind: design

--- a/src/content/blog/2026-06-02-unilink-channelfactory-설계.md
+++ b/src/content/blog/2026-06-02-unilink-channelfactory-설계.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] ChannelFactory 설계'
+title: 'ChannelFactory 설계'
 date: 2026-06-02
 project: unilink
 kind: design

--- a/src/content/blog/2026-06-02-unilink-transport-계층-설계.md
+++ b/src/content/blog/2026-06-02-unilink-transport-계층-설계.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] transport 계층 설계'
+title: 'Transport 계층 설계'
 date: 2026-06-02
 project: unilink
 kind: design

--- a/src/content/blog/2026-06-02-unilink-wrapper-계층-설계.md
+++ b/src/content/blog/2026-06-02-unilink-wrapper-계층-설계.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] wrapper 계층 설계'
+title: 'Wrapper 계층 설계'
 date: 2026-06-02
 project: unilink
 kind: design

--- a/src/content/blog/2026-06-03-unilink-backpressure-설계.md
+++ b/src/content/blog/2026-06-03-unilink-backpressure-설계.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] backpressure 설계'
+title: 'Backpressure 설계'
 date: 2026-06-03
 project: unilink
 kind: design

--- a/src/content/blog/2026-06-03-unilink-framer-계층-설계.md
+++ b/src/content/blog/2026-06-03-unilink-framer-계층-설계.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] framer 계층 설계'
+title: 'Framer 계층 설계'
 date: 2026-06-03
 project: unilink
 kind: design

--- a/src/content/blog/2026-06-03-unilink-memory-buffer-설계.md
+++ b/src/content/blog/2026-06-03-unilink-memory-buffer-설계.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] memory / buffer 설계'
+title: 'Memory / buffer 설계'
 date: 2026-06-03
 project: unilink
 kind: design

--- a/src/content/blog/2026-06-03-unilink-runtimestats와-diagnostics-설계.md
+++ b/src/content/blog/2026-06-03-unilink-runtimestats와-diagnostics-설계.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] RuntimeStats와 Diagnostics 설계'
+title: 'RuntimeStats와 Diagnostics 설계'
 date: 2026-06-03
 project: unilink
 kind: design

--- a/src/content/blog/2026-06-03-unilink-설계-회고.md
+++ b/src/content/blog/2026-06-03-unilink-설계-회고.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] 설계 회고'
+title: '설계 회고'
 date: 2026-06-03
 project: unilink
 kind: retrospective

--- a/src/content/blog/2026-07-02-unilink-tcp-nodelay-트러블슈팅.md
+++ b/src/content/blog/2026-07-02-unilink-tcp-nodelay-트러블슈팅.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] TCP_NODELAY 트러블슈팅'
+title: 'TCP_NODELAY 트러블슈팅'
 date: 2026-07-02
 updatedAt: 2026-07-02
 project: unilink

--- a/src/content/blog/2026-07-02-unilink-udp-backpressure-데드락-트러블슈팅.md
+++ b/src/content/blog/2026-07-02-unilink-udp-backpressure-데드락-트러블슈팅.md
@@ -1,5 +1,5 @@
 ---
-title: '[unilink] UDP backpressure 데드락 트러블슈팅'
+title: 'UDP backpressure 데드락 트러블슈팅'
 date: 2026-07-02
 updatedAt: 2026-07-02
 project: unilink


### PR DESCRIPTION
## Summary
- LLM 글 시리즈화 때 뗀 `[LLM-core]`/`[LLM-training]` 제목 접두어와 같은 이유로, `unilink`(14편)·`AI Curator`(2편)·`STL`(1편, draft) 글의 대괄호 접두어를 전부 제거
- series 네비게이션과 project 뱃지가 이미 그 맥락을 제공하고 있어서 제목의 접두어는 중복 정보였음
- site 글은 원래부터 접두어가 없어서 이제 전체 블로그가 일관됨
- 파일명(=URL)은 건드리지 않음

## Test plan
- [x] `npm run check` 통과
- [x] `grep`으로 모든 title에서 대괄호 접두어 제거 확인
- [x] 빌드 결과에서 제목이 올바르게 렌더링되는지 확인
- [x] URL(파일명)이 변경되지 않았는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)